### PR TITLE
Updated FHIR base template to 0.6.0

### DIFF
--- a/package-list.json
+++ b/package-list.json
@@ -11,10 +11,19 @@
             "current": true
         },
         {
-            "version": "0.0.2",
+            "version": "0.2.0",
             "date": "2020-02-03",
             "desc": "First Release",
-            "path": "http://fhir.org/templates/cqf.fhir.template/0.0.2",
+            "path": "http://fhir.org/templates/cqf.fhir.template/0.2.0",
+            "status": "release",
+            "sequence": "Publications",
+            "current": true
+        },
+        {
+            "version": "0.3.0",
+            "date": "2023-09-27",
+            "desc": "Update to Base FHIR Template 0.6.0",
+            "path": "http://fhir.org/templates/cqf.fhir.template/0.3.0",
             "status": "release",
             "sequence": "Publications",
             "current": true

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqf.fhir.template",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "fhir.template",
   "license": "CC0-1.0",
   "description": "CQF FHIR Template",
@@ -8,6 +8,6 @@
   "canonical": "http://fhir.org/templates/cqf.fhir.template",
   "base": "fhir.base.template",
   "dependencies": {
-    "fhir.base.template": "0.4.0"
+    "fhir.base.template": "0.6.0"
   }
 }


### PR DESCRIPTION
The uplift to fhir.base.template#0.6.0 is needed to resolve the following build error for all IGs using this template:

```
Installing fhir.base.template#0.4.0 done.
Exception in thread "main" java.lang.Error: Template fhir.base.template#0.4.0 names a script, but is not explicit about all ant scripts - this is no longer allowed
	at org.hl7.fhir.igtools.templates.TemplateManager.installTemplate(TemplateManager.java:143)
	at org.hl7.fhir.igtools.templates.TemplateManager.installTemplate(TemplateManager.java:108)
	at org.hl7.fhir.igtools.templates.TemplateManager.installTemplate(TemplateManager.java:108)
	at org.hl7.fhir.igtools.templates.TemplateManager.loadTemplate(TemplateManager.java:79)
	at org.hl7.fhir.igtools.publisher.Publisher.initializeFromIg(Publisher.java:2498)
	at org.hl7.fhir.igtools.publisher.Publisher.initialize(Publisher.java:2368)
	at org.hl7.fhir.igtools.publisher.Publisher.execute(Publisher.java:953)
	at org.hl7.fhir.igtools.publisher.Publisher.main(Publisher.java:12025)
```