### PR TITLE
Accounting for auto-released versions

### DIFF
--- a/package-list.json
+++ b/package-list.json
@@ -3,7 +3,8 @@
     "title": "CQF FHIR Template",
     "canonical": "http://fhir.org/templates/cqf.fhir.template",
     "introduction": "This is the base CQF IG template",
-    "list": [{
+    "list": [
+        {
             "version": "current",
             "desc": "Continuous Integration Build (latest in version control)",
             "path": "https://build.fhir.org/ig/cqframework/cqf-ig-template",
@@ -17,16 +18,25 @@
             "path": "http://fhir.org/templates/cqf.fhir.template/0.2.0",
             "status": "release",
             "sequence": "Publications",
-            "current": true
+            "current": false
         },
         {
             "version": "0.3.0",
-            "date": "2023-09-27",
+            "date": "2023-09-13",
+            "desc": "Update to Base FHIR Template 0.5.0",
+            "path": "http://fhir.org/templates/cqf.fhir.template/0.3.0",
+            "status": "release",
+            "sequence": "Publications",
+            "current": false
+        },
+        {
+            "version": "0.4.0",
+            "date": "2023-09-21",
             "desc": "Update to Base FHIR Template 0.6.0",
             "path": "http://fhir.org/templates/cqf.fhir.template/0.3.0",
             "status": "release",
             "sequence": "Publications",
             "current": true
-        } 
+        }
     ]
 }

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cqf.fhir.template",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "fhir.template",
   "license": "CC0-1.0",
   "description": "CQF FHIR Template",


### PR DESCRIPTION
It appears that the the 0.4.0 and 0.5.0 versions of the base FHIR template had issues that prevented successful IG builds with the latest publisher. All IG templates were released with updated versions of the base FHIR template as a result. This PR is to update our template meta to reflect that.

@brynrhodes should this process be iterative (e.g. a PR for 0.3.0 and 0.4.0 with releases)?